### PR TITLE
Transparency fix and performance improvement

### DIFF
--- a/Assets/BlockEngine/Blocks/BlockLeaves.cs
+++ b/Assets/BlockEngine/Blocks/BlockLeaves.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace BlockEngine.Blocks
 {
-    class BlockLeaves : Block
+    class BlockLeaves : TransparentBlock
     {
 
         private int oak;

--- a/Assets/BlockEngine/Blocks/TransparentBlock.cs
+++ b/Assets/BlockEngine/Blocks/TransparentBlock.cs
@@ -4,86 +4,37 @@
     {
         protected override bool isUpperSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetUpperBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return base.isUpperSolid(chunk, x, y, z);
-            }
+			return false;
         }
 
         protected override bool isLowerSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetLowerBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return base.isLowerSolid(chunk, x, y, z);
-            }
+			return false;
         }
 
         protected override bool isNorthernSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetNorthernBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return base.isNorthernSolid(chunk, x, y, z);
-            }
+			return false;
         }
 
         protected override bool isEasternSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetEasternBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return base.isEasternSolid(chunk, x, y, z);
-            }
+			return false;
         }
 
         protected override bool isSouthernSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetSouthernBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+			return false;
         }
 
         protected override bool isWesternSolid(Chunk chunk, int x, int y, int z)
         {
-            if (GetWesternBlockPrototype(chunk, x, y, z).id == id)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+			return false;
         }
 
         public override bool IsSolid(Block target, Direction direction)
         {
-            if (target.id == id)
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
+			return false;
         }
     }
 }

--- a/Assets/Graphics/OilPaint/ScreenOilPaintEffect/ScreenOilPaintEffect.shader
+++ b/Assets/Graphics/OilPaint/ScreenOilPaintEffect/ScreenOilPaintEffect.shader
@@ -1,4 +1,6 @@
-﻿//Reference:https://www.shadertoy.com/view/MsXSRN#
+﻿// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
+//Reference:https://www.shadertoy.com/view/MsXSRN#
 
 Shader "浅墨Shader编程/Volume10/ScreenOilPaintEffect" 
 {
@@ -69,7 +71,7 @@ Shader "浅墨Shader编程/Volume10/ScreenOilPaintEffect"
 
 				//【2】填充此输出结构
 				//输出的顶点位置为模型视图投影矩阵乘以顶点位置，也就是将三维空间中的坐标投影到了二维窗口
-				Output.vertex = mul(UNITY_MATRIX_MVP, Input.vertex);
+				Output.vertex = UnityObjectToClipPos(Input.vertex);
 				//输出的纹理坐标也就是输入的纹理坐标
 				Output.texcoord = Input.texcoord;
 				//输出的颜色值也就是输入的颜色值

--- a/Assets/Graphics/VolumetricLight/Shaders/BilateralBlur.shader
+++ b/Assets/Graphics/VolumetricLight/Shaders/BilateralBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 //  Copyright(c) 2016, Michal Skalsky
 //  All rights reserved.
 //
@@ -106,7 +108,7 @@ Shader "Hidden/BilateralBlur"
 		v2f vert(appdata v)
 		{
 			v2f o;
-			o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+			o.vertex = UnityObjectToClipPos(v.vertex);
 			o.uv = v.uv;
 			return o;
 		}
@@ -117,7 +119,7 @@ Shader "Hidden/BilateralBlur"
 		v2fDownsample vertDownsampleDepth(appdata v, float2 texelSize)
 		{
 			v2fDownsample o;
-			o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+			o.vertex = UnityObjectToClipPos(v.vertex);
 #if SHADER_TARGET > 40
 			o.uv = v.uv;
 #else
@@ -135,7 +137,7 @@ Shader "Hidden/BilateralBlur"
         v2fUpsample vertUpsample(appdata v, float2 texelSize)
         {
             v2fUpsample o;
-            o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+            o.vertex = UnityObjectToClipPos(v.vertex);
             o.uv = v.uv;
 
             o.uv00 = v.uv - 0.5 * texelSize.xy;

--- a/Assets/Graphics/VolumetricLight/Shaders/BlitAdd.shader
+++ b/Assets/Graphics/VolumetricLight/Shaders/BlitAdd.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 //  Copyright(c) 2016, Michal Skalsky
 //  All rights reserved.
 //
@@ -63,7 +65,7 @@ Shader "Hidden/BlitAdd"
 			v2f vert(appdata_t v)
 			{
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord.xy, _MainTex);
 
 				return o;

--- a/Assets/Graphics/VolumetricLight/Shaders/VolumetricLight.shader
+++ b/Assets/Graphics/VolumetricLight/Shaders/VolumetricLight.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Object2World' with 'unity_ObjectToWorld'
 // Upgrade NOTE: replaced 'unity_World2Shadow' with 'unity_WorldToShadow'
 
@@ -607,7 +609,7 @@ Shader "Sandbox/VolumetricLight"
 			{
 				PSInput o;
 
-				o.pos = mul(UNITY_MATRIX_MVP, i.vertex);
+				o.pos = UnityObjectToClipPos(i.vertex);
 				o.uv = i.uv;
 
 				// SV_VertexId doesn't work on OpenGL for some reason -> reconstruct id from uv

--- a/Assets/Graphics/VolumetricLight/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
+++ b/Assets/Graphics/VolumetricLight/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Tonemapper" {
 	Properties {
 		_MainTex ("", 2D) = "black" {}
@@ -28,7 +30,7 @@ Shader "Hidden/Tonemapper" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Resources/MeshBlocks.meta
+++ b/Assets/Resources/MeshBlocks.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 37a1d9ffa8f38114d974995262c6fdfc
-folderAsset: yes
-timeCreated: 1492829977
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Standard Assets/Effects/GlassRefraction/Shaders/GlassStainedBumpDistort.shader
+++ b/Assets/Standard Assets/Effects/GlassRefraction/Shaders/GlassStainedBumpDistort.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Per pixel bumped refraction.
 // Uses a normal map to distort the image behind, and
 // an additional texture to tint the color.
@@ -56,7 +58,7 @@ float4 _MainTex_ST;
 v2f vert (appdata_t v)
 {
 	v2f o;
-	o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.vertex = UnityObjectToClipPos(v.vertex);
 	#if UNITY_UV_STARTS_AT_TOP
 	float scale = -1.0;
 	#else

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlendModesOverlay.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlendModesOverlay.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendModesOverlay" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -25,7 +27,7 @@ Shader "Hidden/BlendModesOverlay" {
 		
 	v2f vert( appdata_img v ) { 
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(float2(
 			dot(v.texcoord.xy, _UV_Transform.xy),

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlurEffectConeTaps.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/BlurEffectConeTaps.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlurEffectConeTap" {
 	Properties { _MainTex ("", any) = "" {} }
 	CGINCLUDE
@@ -13,7 +15,7 @@ Shader "Hidden/BlurEffectConeTap" {
 	half4 _BlurOffsets;
 	v2f vert( appdata_img v ) {
 		v2f o; 
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv = v.texcoord - _BlurOffsets.xy * _MainTex_TexelSize.xy; // hack, see BlurEffect.cs for the reason for this. let's make a new blur effect soon
 #ifdef UNITY_SINGLE_PASS_STEREO

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  /*
  	CAMERA MOTION BLUR IMAGE EFFECTS
 
@@ -95,7 +97,7 @@
 	v2f vert(appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlurDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CameraMotionBlurDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  /*
  	NOTES: see CameraMotionBlur.shader
  */
@@ -52,7 +54,7 @@
 	v2f vert(appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ChromaticAberrationShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ChromaticAberrationShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ChromaticAberration" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -24,7 +26,7 @@ Shader "Hidden/ChromaticAberration" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrection3DLut.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrection3DLut.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrection3DLut" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}		
@@ -24,7 +26,7 @@ float _Offset;
 v2f vert( appdata_img v ) 
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 	return o;
 } 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurves.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurves.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionCurves" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -40,7 +42,7 @@ Shader "Hidden/ColorCorrectionCurves" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv2 = TRANSFORM_TEX(v.texcoord, _CameraDepthTexture);
 		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurvesSimple.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionCurvesSimple.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionCurvesSimple" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -23,7 +25,7 @@ Shader "Hidden/ColorCorrectionCurvesSimple" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionSelective.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ColorCorrectionSelective.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ColorCorrectionSelective" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -20,7 +22,7 @@ Shader "Hidden/ColorCorrectionSelective" {
 	
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/Apply.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/Apply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Final pass in the contrast stretch effect: apply
 // color stretch to the original image, based on currently
 // adapted to minimum/maximum luminances.
@@ -30,7 +32,7 @@ half4 _MainTex_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv[0] = MultiplyUV (UNITY_MATRIX_TEXTURE0, UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST));
 	o.uv[1] = float2(0.5,0.5);
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/MinMaxReduction.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Contrast Stretch/MinMaxReduction.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Reduces input image (_MainTex) by 2x2.
 // Outputs maximum value in R, minimum in G.
 Shader "Hidden/Contrast Stretch Reduction" {
@@ -26,7 +28,7 @@ half4 _MainTex_ST;
 
 v2f vert (appdata_img v) {
 	v2f o;
-	o.position = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.position = UnityObjectToClipPos (v.vertex);
 	float2 uv = MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord);
 	
 	// Compute UVs to sample 2x2 pixel block.

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ContrastComposite.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ContrastComposite.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ContrastComposite" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -27,7 +29,7 @@ Shader "Hidden/ContrastComposite" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTexBlurred_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ConvertDepth.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ConvertDepth.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/ConvertDepth" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -21,7 +23,7 @@ Shader "Hidden/ConvertDepth" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _CameraDepthTexture_ST);
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/CreaseApply.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/CreaseApply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/CreaseApply" {
@@ -34,7 +36,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv.xy = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/EdgeDetectNormals.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/EdgeDetectNormals.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/EdgeDetect" { 
 	Properties {
@@ -44,7 +46,7 @@ Shader "Hidden/EdgeDetect" {
 	v2flum vertLum (appdata_img v)
 	{
 		v2flum o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		float2 uv = MultiplyUV( UNITY_MATRIX_TEXTURE0, v.texcoord );
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(uv, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(uv + float2(-_MainTex_TexelSize.x, -_MainTex_TexelSize.y) * _SampleDistance, _MainTex_ST);
@@ -94,7 +96,7 @@ Shader "Hidden/EdgeDetect" {
 	v2f vertRobert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(uv, _MainTex_ST);
@@ -118,7 +120,7 @@ Shader "Hidden/EdgeDetect" {
 	v2f vertThin( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(uv, _MainTex_ST);
@@ -141,7 +143,7 @@ Shader "Hidden/EdgeDetect" {
 	v2fd vertD( appdata_img v )
 	{
 		v2fd o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv[0] = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/FisheyeShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/FisheyeShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FisheyeShader" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -21,7 +23,7 @@ Shader "Hidden/FisheyeShader" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/GlobalFog.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/GlobalFog.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/GlobalFog" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "black" {}
@@ -49,7 +51,7 @@ CGINCLUDE
 	{
 		v2f o;
 		v.vertex.z = 0.1;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv_depth = v.texcoord.xy;
 		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/MotionBlur" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -36,7 +38,7 @@ Properties {
 			v2f vert (appdata_t v)
 			{
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				return o;
 			}
@@ -80,7 +82,7 @@ Properties {
 			v2f vert (appdata_t v)
 			{
 				v2f o;
-				o.vertex = mul(UNITY_MATRIX_MVP, v.vertex);
+				o.vertex = UnityObjectToClipPos(v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				return o;
 			}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlurClear.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/MotionBlurClear.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/MotionBlurClear" 
 {
@@ -31,7 +33,7 @@ Pass {
 	ps_input vert (vs_input v)
 	{
 		ps_input o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos (v.vertex);	
 		o.screen = ComputeScreenPos(o.pos);
 		COMPUTE_EYEDEPTH(o.screen.z);
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrain.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrain.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/NoiseAndGrain" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -47,7 +49,7 @@ Shader "Hidden/NoiseAndGrain" {
 		{
 			v2f o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+			o.pos = UnityObjectToClipPos (v.vertex);	
 			
 		#if UNITY_UV_STARTS_AT_TOP
 			o.uv_screen = v.vertex.xyxy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrainDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseAndGrainDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/NoiseAndGrainDX11" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -72,7 +74,7 @@ Shader "Hidden/NoiseAndGrainDX11" {
 		{
 			v2f o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);	
+			o.pos = UnityObjectToClipPos (v.vertex);	
 			
 		#if UNITY_UV_STARTS_AT_TOP
 			o.uv_screen = v.vertex.xyxy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderRGB.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderRGB.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Noise Shader RGB" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -34,7 +36,7 @@ half4 _MainTex_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = UnityStereoScreenSpaceUVAdjust(MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord), _MainTex_ST);
 	o.uvg = v.texcoord.xy * _GrainOffsetScale.zw + _GrainOffsetScale.xy;
 	o.uvs = v.texcoord.xy * _ScratchOffsetScale.zw + _ScratchOffsetScale.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderYUV.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/NoiseEffectShaderYUV.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Noise Shader YUV" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -34,7 +36,7 @@ half4 _MainTex_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = UnityStereoScreenSpaceUVAdjust(MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord), _MainTex_ST);
 	o.uvg = v.texcoord.xy * _GrainOffsetScale.zw + _GrainOffsetScale.xy;
 	o.uvs = v.texcoord.xy * _ScratchOffsetScale.zw + _ScratchOffsetScale.xy;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/PrepareSunShaftsBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/PrepareSunShaftsBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/PrepareSunShaftsBlur" {
 	Properties {
@@ -23,7 +25,7 @@ Shader "Hidden/PrepareSunShaftsBlur" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	}  

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/RadialBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/RadialBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/RadialBlur" 
 {
 	Properties {
@@ -24,7 +26,7 @@ Shader "Hidden/RadialBlur"
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy =  v.texcoord.xy;
 		
 		o.blurVector = (_SunPosition.xy - v.texcoord.xy) * _BlurRadius4.xy;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SSAOShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SSAOShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SSAO" {
 Properties {
 	_MainTex ("", 2D) = "" {}
@@ -22,7 +24,7 @@ float4 _CameraDepthNormalsTexture_ST;
 v2f_ao vert_ao (appdata_img v)
 {
 	v2f_ao o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = TRANSFORM_TEX(v.texcoord, _CameraDepthNormalsTexture);
 	o.uvr = v.texcoord.xy * _NoiseScale;
 	return o;
@@ -184,7 +186,7 @@ float4 _MainTex_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = TRANSFORM_TEX (v.texcoord, _CameraDepthNormalsTexture);
 	return o;
 }
@@ -259,7 +261,7 @@ half4 _SSAO_ST;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv[0] = UnityStereoScreenSpaceUVAdjust(MultiplyUV (UNITY_MATRIX_TEXTURE0, v.texcoord), _MainTex_ST);
 	o.uv[1] = UnityStereoScreenSpaceUVAdjust(MultiplyUV (UNITY_MATRIX_TEXTURE1, v.texcoord), _SSAO_ST);
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ScreenSpaceAmbientObscurance.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ScreenSpaceAmbientObscurance.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 // This Ambient Occlusion image effect is based on "Scalable Ambient Obscurance":
 
@@ -82,7 +84,7 @@ Shader "Hidden/ScreenSpaceAmbientObscurance"
 	v2f vert( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv2 = v.texcoord.xy;
 		#if UNITY_UV_STARTS_AT_TOP

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/ShowAlphaChannel.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/ShowAlphaChannel.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/ShowAlphaChannel" {
@@ -31,7 +33,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	
 	return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SimpleClear.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SimpleClear.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 Shader "Hidden/SimpleClear" {
@@ -24,7 +26,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	return o;
 }
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/SunShaftsComposite.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/SunShaftsComposite.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SunShaftsComposite" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -45,7 +47,7 @@ Shader "Hidden/SunShaftsComposite" {
 			
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		
 		#if UNITY_UV_STARTS_AT_TOP
@@ -81,7 +83,7 @@ Shader "Hidden/SunShaftsComposite" {
 	
 	v2f_radial vert_radial( appdata_img v ) {
 		v2f_radial o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		
 		o.uv.xy =  v.texcoord.xy;
 		o.blurVector = (_SunPosition.xy - v.texcoord.xy) * _BlurRadius4.xy;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/Tonemapper.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Tonemapper" {
 	Properties {
 		_MainTex ("", 2D) = "black" {}
@@ -29,7 +31,7 @@ Shader "Hidden/Tonemapper" {
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/TwirlEffect.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/TwirlEffect.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Twirt Effect Shader" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -26,7 +28,7 @@ struct v2f {
 v2f vert( appdata_img v )
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord - _CenterRadius.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/VignettingShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/VignettingShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Vignetting" {
 	Properties {
 		_MainTex ("Base", 2D) = "white" {}
@@ -26,7 +28,7 @@ Shader "Hidden/Vignetting" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = v.texcoord.xy;
 		o.uv2 = v.texcoord.xy;
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/VortexEffect.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/VortexEffect.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Twist Effect" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -32,7 +34,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos(v.vertex);
 	float2 uv = v.texcoord.xy - _CenterRadius.xy;
 	o.uv = TRANSFORM_TEX(uv, _MainTex); //MultiplyUV (UNITY_MATRIX_TEXTURE0, uv);
 	o.uvOrig = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/DLAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/DLAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 //
 // modified and adapted DLAA code based on Dmitry Andreev's
@@ -279,7 +281,7 @@ CGINCLUDE
 
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 		o.uv.xy = uv;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA II" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -169,7 +171,7 @@ float4 _MainTex_TexelSize;
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = FxaaVertexShader (v.texcoord.xy*2-1, _MainTex_TexelSize.xy);
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA3Console.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAA3Console.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 
 /*============================================================================
@@ -65,7 +67,7 @@ Shader "Hidden/FXAA III (Console)" {
 		v2f vert (appdata_img v)
 		{
 			v2f o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = v.texcoord.xy;
 			

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA Preset 2" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -808,7 +810,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset3.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/FXAAPreset3.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/FXAA Preset 3" {
 Properties {
 	_MainTex ("Base (RGB)", 2D) = "white" {}
@@ -807,7 +809,7 @@ struct v2f {
 v2f vert (appdata_img v)
 {
 	v2f o;
-	o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+	o.pos = UnityObjectToClipPos (v.vertex);
 	o.uv = v.texcoord.xy;
 	return o;
 }

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/NFAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/NFAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/NFAA" {
 Properties {
@@ -24,7 +26,7 @@ struct v2f {
 	v2f vert( appdata_img v )
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 				

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/SSAA.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_Antialiasing/SSAA.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/SSAA" {
 Properties {
@@ -29,7 +31,7 @@ SubShader {
 
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		
 		float2 uv = v.texcoord.xy;
 	    

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/Blend.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/Blend.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/Blend" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -28,7 +30,7 @@ Shader "Hidden/Blend" {
 
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = v.texcoord.xy;
 		o.uv[1] = v.texcoord.xy;
 		
@@ -42,7 +44,7 @@ Shader "Hidden/Blend" {
 
 	v2f_mt vertMultiTap( appdata_img v ) {
 		v2f_mt o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = v.texcoord.xy + _MainTex_TexelSize.xy * 0.5;
 		o.uv[1] = v.texcoord.xy - _MainTex_TexelSize.xy * 0.5;
 		o.uv[2] = v.texcoord.xy - _MainTex_TexelSize.xy * half2(1,-1) * 0.5;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendForBloom.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendForBloom.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendForBloom" {
 	Properties {
 		_MainTex ("Screen Blended", 2D) = "" {}
@@ -28,7 +30,7 @@ Shader "Hidden/BlendForBloom" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] =  v.texcoord.xy;
 		o.uv[1] =  v.texcoord.xy;
 		
@@ -42,7 +44,7 @@ Shader "Hidden/BlendForBloom" {
 
 	v2f_mt vertMultiTap( appdata_img v ) {
 		v2f_mt o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[4] = v.texcoord.xy;
 		o.uv[0] = v.texcoord.xy + _MainTex_TexelSize.xy * 0.5;
 		o.uv[1] = v.texcoord.xy - _MainTex_TexelSize.xy * 0.5;	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendOneOne.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlendOneOne.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlendOneOne" {
 	Properties {
 		_MainTex ("-", 2D) = "" {}
@@ -18,7 +20,7 @@ Shader "Hidden/BlendOneOne" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	}

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlurAndFlares.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BlurAndFlares.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BlurAndFlares" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -42,14 +44,14 @@ Shader "Hidden/BlurAndFlares" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}
 
 	v2f_blur vertWithMultiCoords2 (appdata_img v) {
 		v2f_blur o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv01 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + _Offsets.xyxy * half4(1,1, -1,-1), _MainTex_ST);
 		o.uv23 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + _Offsets.xyxy * half4(1,1, -1,-1) * 2.0, _MainTex_ST);
@@ -61,7 +63,7 @@ Shader "Hidden/BlurAndFlares" {
 
 	v2f_opts vertStretch (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		half b = _StretchWidth;		
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy + b * 2.0 * _Offsets.xy, _MainTex_ST);
@@ -75,7 +77,7 @@ Shader "Hidden/BlurAndFlares" {
 	
 	v2f_opts vertWithMultiCoords (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy + 0.5 * _MainTex_TexelSize.xy * _Offsets.xy, _MainTex_ST);
 		o.uv[2] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy - 0.5 * _MainTex_TexelSize.xy * _Offsets.xy, _MainTex_ST);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BrightPassFilterForBloom"
 {
 	Properties 
@@ -24,7 +26,7 @@ Shader "Hidden/BrightPassFilterForBloom"
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter2.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/BrightPassFilter2.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/BrightPassFilter2"
 {
 	Properties 
@@ -23,7 +25,7 @@ Shader "Hidden/BrightPassFilter2"
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		return o;
 	} 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/LensFlareCreate.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/LensFlareCreate.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/LensFlareCreate" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -22,7 +24,7 @@ Shader "Hidden/LensFlareCreate" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(( ( v.texcoord.xy - 0.5 ) * -0.85 ) + 0.5, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(( ( v.texcoord.xy - 0.5 ) * -1.45 ) + 0.5, _MainTex_ST);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBloom.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBloom.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/FastBloom" {
 	Properties {
@@ -36,7 +38,7 @@ Shader "Hidden/FastBloom" {
 		{
 			v2f_simple o;
 			
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST);
         	
         #if UNITY_UV_STARTS_AT_TOP
@@ -61,7 +63,7 @@ Shader "Hidden/FastBloom" {
 		{
 			v2f_tap o;
 
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv20 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy, _MainTex_ST);
 			o.uv21 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy * half2(-0.5h,-0.5h), _MainTex_ST);
 			o.uv22 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy * half2(0.5h,-0.5h), _MainTex_ST);
@@ -118,7 +120,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoords8 vertBlurHorizontal (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x;
@@ -129,7 +131,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoords8 vertBlurVertical (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;
@@ -157,7 +159,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoordsSGX vertBlurHorizontalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = v.texcoord.xy;
 
@@ -172,7 +174,7 @@ Shader "Hidden/FastBloom" {
 		v2f_withBlurCoordsSGX vertBlurVerticalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MobileBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 Shader "Hidden/FastBlur" {
 	Properties {
@@ -34,7 +36,7 @@ Shader "Hidden/FastBlur" {
 		{
 			v2f_tap o;
 
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
         	o.uv20 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy, _MainTex_ST);
 			o.uv21 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy * half2(-0.5h,-0.5h), _MainTex_ST);
 			o.uv22 = UnityStereoScreenSpaceUVAdjust(v.texcoord + _MainTex_TexelSize.xy * half2(0.5h,-0.5h), _MainTex_ST);
@@ -76,7 +78,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoords8 vertBlurHorizontal (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(1.0, 0.0) * _Parameter.x;
@@ -87,7 +89,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoords8 vertBlurVertical (appdata_img v)
 		{
 			v2f_withBlurCoords8 o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(v.texcoord.xy,1,1);
 			o.offs = _MainTex_TexelSize.xy * half2(0.0, 1.0) * _Parameter.x;
@@ -115,7 +117,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoordsSGX vertBlurHorizontalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 
@@ -130,7 +132,7 @@ Shader "Hidden/FastBlur" {
 		v2f_withBlurCoordsSGX vertBlurVerticalSGX (appdata_img v)
 		{
 			v2f_withBlurCoordsSGX o;
-			o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+			o.pos = UnityObjectToClipPos (v.vertex);
 			
 			o.uv = half4(UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST),1,1);
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MultiPassHollywoodFlares.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/MultiPassHollywoodFlares.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/MultipassHollywoodFlares" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -32,14 +34,14 @@ Shader "Hidden/MultipassHollywoodFlares" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv =  v.texcoord.xy;
 		return o;
 	}
 
 	v2f_opts vertStretch (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		half b = stretchWidth;		
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy + b * 2.0 * offsets.xy, _MainTex_ST);
@@ -53,7 +55,7 @@ Shader "Hidden/MultipassHollywoodFlares" {
 	
 	v2f_opts vertVerticalCoords (appdata_img v) {
 		v2f_opts o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv[0] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv[1] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy + 0.5 * _MainTex_TexelSize.xy * half2(0,1), _MainTex_ST);
 		o.uv[2] = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy - 0.5 * _MainTex_TexelSize.xy * half2(0,1), _MainTex_ST);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/SeparableBlurPlus.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/SeparableBlurPlus.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableBlurPlus" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -23,7 +25,7 @@ Shader "Hidden/SeparableBlurPlus" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv.xy = v.texcoord.xy;
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/VignetteShader.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_BloomAndFlares/VignetteShader.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/VignetteShader" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -19,7 +21,7 @@ Shader "Hidden/VignetteShader" {
 		
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos(v.vertex);	
 		
 		o.uv = v.texcoord.xy;
 		return o;

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfField34.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfField34.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  Shader "Hidden/Dof/DepthOfField34" {
 	Properties {
 		_MainTex ("Base", 2D) = "" {}
@@ -51,14 +53,14 @@
 	
 	v2f vert( appdata_img v ) {
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		return o;
 	} 
 
 	v2fRadius vertWithRadius( appdata_img v ) {
 		v2fRadius o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 
 		const half2 blurOffsets[4] = {
@@ -83,14 +85,14 @@
 	
 	v2fDofApply vertDofApply( appdata_img v ) {
 		v2fDofApply o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		return o;
 	} 	
 		
 	v2fDown vertDownsampleWithCocConserve(appdata_img v) {
 		v2fDown o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);	
+		o.pos = UnityObjectToClipPos(v.vertex);	
 		o.uv0.xy = v.texcoord.xy;
 		o.uv[0].xy = v.texcoord.xy + half2(-1.0,-1.0) * _InvRenderTargetSize;
 		o.uv[1].xy = v.texcoord.xy + half2(1.0,-1.0) * _InvRenderTargetSize;		

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldDX11.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldDX11.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
 /*
 	DX11 Depth Of Field
@@ -161,7 +163,7 @@ Pass
 	v2f vert (appdata v)
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv = UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST);
 		o.uv_flip = UnityStereoScreenSpaceUVAdjust(v.texcoord, _MainTex_ST);
 		#if UNITY_UV_STARTS_AT_TOP

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldScatter.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/DepthOfFieldScatter.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
  Shader "Hidden/Dof/DepthOfFieldHdr" {
 	Properties {
 		_MainTex ("-", 2D) = "black" {}
@@ -47,7 +49,7 @@
 	v2f vert( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		o.uv.xy = v.texcoord.xy;
 		
@@ -62,7 +64,7 @@
 	v2f vertFlip( appdata_img v ) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv1.xy = v.texcoord.xy;
 		o.uv.xy = v.texcoord.xy;
 		
@@ -79,7 +81,7 @@
 	v2fBlur vertBlurPlusMinus (appdata_img v) 
 	{
 		v2fBlur o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv01 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + _Offsets.xyxy * float4(1,1, -1,-1) * _MainTex_TexelSize.xyxy / 6.0, _MainTex_ST);
 		o.uv23 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + _Offsets.xyxy * float4(2,2, -2,-2) * _MainTex_TexelSize.xyxy / 6.0, _MainTex_ST);

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableBlur" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -23,7 +25,7 @@ Shader "Hidden/SeparableBlur" {
 		
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		o.uv.xy = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableWeightedBlurDof34.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/SeparableWeightedBlurDof34.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Hidden/SeparableWeightedBlurDof34" {
 	Properties {
 		_MainTex ("Base (RGB)", 2D) = "" {}
@@ -36,7 +38,7 @@ Shader "Hidden/SeparableWeightedBlurDof34" {
 	
 	v2f vert (appdata_img v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = UnityStereoScreenSpaceUVAdjust(v.texcoord.xy, _MainTex_ST);
 		o.uv01 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + offsets.xyxy * half4(1,1, -1,-1), _MainTex_ST);
 		o.uv23 =  UnityStereoScreenSpaceUVAdjust(v.texcoord.xyxy + offsets.xyxy * half4(1,1, -1,-1) * 2.0, _MainTex_ST);
@@ -47,7 +49,7 @@ Shader "Hidden/SeparableWeightedBlurDof34" {
 	
 	v2fSingle vertSingleTex (appdata_img v) {
 		v2fSingle o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 		o.uv.xy = v.texcoord.xy;
 		return o;  
 	}	

--- a/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/TiltShiftHdrLensBlur.shader
+++ b/Assets/Standard Assets/Effects/ImageEffects/Shaders/_DepthOfField/TiltShiftHdrLensBlur.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 
  Shader "Hidden/Dof/TiltShiftHdrLensBlur" {
 	Properties {
@@ -34,7 +36,7 @@
 	v2f vert (appdata_img v) 
 	{
 		v2f o;
-		o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos (v.vertex);
 		o.uv.xy = v.texcoord;
 		o.uv1.xy = v.texcoord;
 

--- a/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorLight.shader
+++ b/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorLight.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Projector' with 'unity_Projector'
 // Upgrade NOTE: replaced '_ProjectorClip' with 'unity_ProjectorClip'
 
@@ -35,7 +37,7 @@ Shader "Projector/Light" {
 			v2f vert (float4 vertex : POSITION)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, vertex);
+				o.pos = UnityObjectToClipPos (vertex);
 				o.uvShadow = mul (unity_Projector, vertex);
 				o.uvFalloff = mul (unity_ProjectorClip, vertex);
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorMultiply.shader
+++ b/Assets/Standard Assets/Effects/Projectors/Shaders/ProjectorMultiply.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 // Upgrade NOTE: replaced '_Projector' with 'unity_Projector'
 // Upgrade NOTE: replaced '_ProjectorClip' with 'unity_ProjectorClip'
 
@@ -33,7 +35,7 @@ Shader "Projector/Multiply" {
 			v2f vert (float4 vertex : POSITION)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, vertex);
+				o.pos = UnityObjectToClipPos (vertex);
 				o.uvShadow = mul (unity_Projector, vertex);
 				o.uvFalloff = mul (unity_ProjectorClip, vertex);
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasic.shader
+++ b/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasic.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Toon/Basic" {
 	Properties {
 		_Color ("Main Color", Color) = (.5,.5,.5,1)
@@ -40,7 +42,7 @@ Shader "Toon/Basic" {
 			v2f vert (appdata v)
 			{
 				v2f o;
-				o.pos = mul (UNITY_MATRIX_MVP, v.vertex);
+				o.pos = UnityObjectToClipPos (v.vertex);
 				o.texcoord = TRANSFORM_TEX(v.texcoord, _MainTex);
 				o.cubenormal = mul (UNITY_MATRIX_MV, float4(v.normal,0));
 				UNITY_TRANSFER_FOG(o,o.pos);

--- a/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasicOutline.shader
+++ b/Assets/Standard Assets/Effects/ToonShading/Shaders/ToonBasicOutline.shader
@@ -1,3 +1,5 @@
+// Upgrade NOTE: replaced 'mul(UNITY_MATRIX_MVP,*)' with 'UnityObjectToClipPos(*)'
+
 Shader "Toon/Basic Outline" {
 	Properties {
 		_Color ("Main Color", Color) = (.5,.5,.5,1)
@@ -26,7 +28,7 @@ Shader "Toon/Basic Outline" {
 	
 	v2f vert(appdata v) {
 		v2f o;
-		o.pos = mul(UNITY_MATRIX_MVP, v.vertex);
+		o.pos = UnityObjectToClipPos(v.vertex);
 
 		float3 norm   = normalize(mul ((float3x3)UNITY_MATRIX_IT_MV, v.normal));
 		float2 offset = TransformViewToProjection(norm.xy);


### PR DESCRIPTION
Fixes #1 and makes leaves transparent by default.

Also upgrades shader behavior to use UnityObjectToClipPos in order to improve performance.